### PR TITLE
Hs/timezone publish to profile

### DIFF
--- a/res/css/views/right_panel/_UserInfo.pcss
+++ b/res/css/views/right_panel/_UserInfo.pcss
@@ -133,9 +133,7 @@ limitations under the License.
     }
 
     .mx_UserInfo_timezone {
-        .mx_UserInfo_profileStatus {
-            margin: var(--cpd-space-1x) 0;
-        }
+        margin: var(--cpd-space-1x) 0;
     }
 
     .mx_PresenceLabel {

--- a/res/css/views/right_panel/_UserInfo.pcss
+++ b/res/css/views/right_panel/_UserInfo.pcss
@@ -132,6 +132,12 @@ limitations under the License.
         }
     }
 
+    .mx_UserInfo_timezone {
+        .mx_UserInfo_profileStatus {
+            margin: var(--cpd-space-1x) 0;
+        }
+    }
+
     .mx_PresenceLabel {
         font: var(--cpd-font-body-sm-regular);
         opacity: 1;

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -139,6 +139,7 @@ class LoggedInView extends React.Component<IProps, IState> {
     protected layoutWatcherRef?: string;
     protected compactLayoutWatcherRef?: string;
     protected backgroundImageWatcherRef?: string;
+    protected timezoneProfileUpdateRef?: string[];
     protected resizer?: Resizer<ICollapseConfig, CollapseItem>;
 
     public constructor(props: IProps) {
@@ -190,6 +191,21 @@ class LoggedInView extends React.Component<IProps, IState> {
             this.refreshBackgroundImage,
         );
 
+
+        this.timezoneProfileUpdateRef = [
+            SettingsStore.watchSetting(
+                "userTimezonePublish",
+                null,
+                this.onTimezoneUpdate,
+            ),
+            SettingsStore.watchSetting(
+                "userTimezone",
+                null,
+                this.onTimezoneUpdate,
+            ),
+
+        ];
+
         this.resizer = this.createResizer();
         this.resizer.attach();
 
@@ -197,6 +213,28 @@ class LoggedInView extends React.Component<IProps, IState> {
         this.loadResizerPreferences();
         this.refreshBackgroundImage();
     }
+
+    private onTimezoneUpdate = async (): Promise<void> => {
+        console.log('Triggering timezoen update', SettingsStore);
+        if (!SettingsStore.getValue("userTimezonePublish")) {
+            // Ensure it's deleted
+            try {
+                await this._matrixClient.deleteExtendedProfileProperty("us.cloke.msc4175.tz");
+            } catch (ex) {
+                console.warn("Failed to delete timezone from user profile", ex);
+            }
+            return;
+        }
+        const currentTimezone = SettingsStore.getValue("userTimezone");
+        if (!currentTimezone || typeof currentTimezone !== "string") {
+            return;
+        }
+        try {
+            await this._matrixClient.setExtendedProfileProperty("us.cloke.msc4175.tz", currentTimezone)
+        } catch (ex) {
+            console.warn("Failed to update user profile with current timezone", ex);
+        }
+    };
 
     public componentWillUnmount(): void {
         document.removeEventListener("keydown", this.onNativeKeyDown, false);
@@ -208,6 +246,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         if (this.layoutWatcherRef) SettingsStore.unwatchSetting(this.layoutWatcherRef);
         if (this.compactLayoutWatcherRef) SettingsStore.unwatchSetting(this.compactLayoutWatcherRef);
         if (this.backgroundImageWatcherRef) SettingsStore.unwatchSetting(this.backgroundImageWatcherRef);
+        this.timezoneProfileUpdateRef?.forEach(s => SettingsStore.unwatchSetting(s));
         this.resizer?.detach();
     }
 

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -214,9 +214,10 @@ class LoggedInView extends React.Component<IProps, IState> {
             }
             return;
         }
-        const currentTimezone = SettingsStore.getValue("userTimezone") 
-        // If the timezone is empty, then use the browser timezone.
-            || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const currentTimezone =
+            SettingsStore.getValue("userTimezone") ||
+            // If the timezone is empty, then use the browser timezone.
+            Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (!currentTimezone || typeof currentTimezone !== "string") {
             return;
         }

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -191,19 +191,9 @@ class LoggedInView extends React.Component<IProps, IState> {
             this.refreshBackgroundImage,
         );
 
-
         this.timezoneProfileUpdateRef = [
-            SettingsStore.watchSetting(
-                "userTimezonePublish",
-                null,
-                this.onTimezoneUpdate,
-            ),
-            SettingsStore.watchSetting(
-                "userTimezone",
-                null,
-                this.onTimezoneUpdate,
-            ),
-
+            SettingsStore.watchSetting("userTimezonePublish", null, this.onTimezoneUpdate),
+            SettingsStore.watchSetting("userTimezone", null, this.onTimezoneUpdate),
         ];
 
         this.resizer = this.createResizer();
@@ -215,7 +205,7 @@ class LoggedInView extends React.Component<IProps, IState> {
     }
 
     private onTimezoneUpdate = async (): Promise<void> => {
-        console.log('Triggering timezoen update', SettingsStore);
+        console.log("Triggering timezoen update", SettingsStore);
         if (!SettingsStore.getValue("userTimezonePublish")) {
             // Ensure it's deleted
             try {
@@ -230,7 +220,7 @@ class LoggedInView extends React.Component<IProps, IState> {
             return;
         }
         try {
-            await this._matrixClient.setExtendedProfileProperty("us.cloke.msc4175.tz", currentTimezone)
+            await this._matrixClient.setExtendedProfileProperty("us.cloke.msc4175.tz", currentTimezone);
         } catch (ex) {
             console.warn("Failed to update user profile with current timezone", ex);
         }
@@ -246,7 +236,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         if (this.layoutWatcherRef) SettingsStore.unwatchSetting(this.layoutWatcherRef);
         if (this.compactLayoutWatcherRef) SettingsStore.unwatchSetting(this.compactLayoutWatcherRef);
         if (this.backgroundImageWatcherRef) SettingsStore.unwatchSetting(this.backgroundImageWatcherRef);
-        this.timezoneProfileUpdateRef?.forEach(s => SettingsStore.unwatchSetting(s));
+        this.timezoneProfileUpdateRef?.forEach((s) => SettingsStore.unwatchSetting(s));
         this.resizer?.detach();
     }
 

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -217,6 +217,7 @@ class LoggedInView extends React.Component<IProps, IState> {
         const currentTimezone =
             SettingsStore.getValue("userTimezone") ||
             // If the timezone is empty, then use the browser timezone.
+            // eslint-disable-next-line new-cap
             Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (!currentTimezone || typeof currentTimezone !== "string") {
             return;

--- a/src/components/structures/LoggedInView.tsx
+++ b/src/components/structures/LoggedInView.tsx
@@ -205,7 +205,6 @@ class LoggedInView extends React.Component<IProps, IState> {
     }
 
     private onTimezoneUpdate = async (): Promise<void> => {
-        console.log("Triggering timezoen update", SettingsStore);
         if (!SettingsStore.getValue("userTimezonePublish")) {
             // Ensure it's deleted
             try {
@@ -215,7 +214,9 @@ class LoggedInView extends React.Component<IProps, IState> {
             }
             return;
         }
-        const currentTimezone = SettingsStore.getValue("userTimezone");
+        const currentTimezone = SettingsStore.getValue("userTimezone") 
+        // If the timezone is empty, then use the browser timezone.
+            || Intl.DateTimeFormat().resolvedOptions().timeZone;
         if (!currentTimezone || typeof currentTimezone !== "string") {
             return;
         }

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1702,7 +1702,7 @@ export const UserInfoHeader: React.FC<{
         );
     }
 
-    const timezoneInfo = useUserTimezone(member.userId);
+    const timezoneInfo = useUserTimezone(cli, member.userId);
 
     const e2eIcon = e2eStatus ? <E2EIcon size={18} status={e2eStatus} isUser={true} /> : null;
     const userIdentifier = UserIdentifierCustomisations.getDisplayUserIdentifier?.(member.userId, {
@@ -1710,6 +1710,7 @@ export const UserInfoHeader: React.FC<{
         withDisplayName: true,
     });
     const displayName = (member as RoomMember).rawDisplayName;
+    console.log("booop", timezoneInfo);
     return (
         <React.Fragment>
             <div className="mx_UserInfo_avatar">

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -29,7 +29,6 @@ import {
     User,
     Device,
     EventType,
-    MatrixError,
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { UserVerificationStatus, VerificationRequest } from "matrix-js-sdk/src/crypto-api";
@@ -1703,7 +1702,6 @@ export const UserInfoHeader: React.FC<{
         );
     }
 
-
     const timezoneInfo = useUserTimezone(member.userId);
 
     const e2eIcon = e2eStatus ? <E2EIcon size={18} status={e2eStatus} isUser={true} /> : null;
@@ -1738,7 +1736,14 @@ export const UserInfoHeader: React.FC<{
                             {e2eIcon}
                         </Flex>
                     </Heading>
-                    {presenceLabel} {timezoneInfo && <Tooltip label={timezoneInfo.timezone}><span>{timezoneInfo.friendly}</span></Tooltip>}
+                    {presenceLabel}
+                    <Tooltip label={timezoneInfo?.timezone ?? ""}>
+                        <span className="mx_UserInfo_timezone">
+                            <Text size="sm" weight="regular">
+                                {timezoneInfo?.friendly ?? ""}
+                            </Text>
+                        </span>
+                    </Tooltip>
                     <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
                         <CopyableText getTextToCopy={() => userIdentifier} border={false}>
                             {userIdentifier}

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1710,7 +1710,6 @@ export const UserInfoHeader: React.FC<{
         withDisplayName: true,
     });
     const displayName = (member as RoomMember).rawDisplayName;
-    console.log("booop", timezoneInfo);
     return (
         <React.Fragment>
             <div className="mx_UserInfo_avatar">
@@ -1738,13 +1737,15 @@ export const UserInfoHeader: React.FC<{
                         </Flex>
                     </Heading>
                     {presenceLabel}
-                    {timezoneInfo && <Tooltip label={timezoneInfo?.timezone ?? ""}>
-                        <span className="mx_UserInfo_timezone">
-                            <Text size="sm" weight="regular">
-                                {timezoneInfo?.friendly ?? ""}
-                            </Text>
-                        </span>
-                    </Tooltip>}
+                    {timezoneInfo && (
+                        <Tooltip label={timezoneInfo?.timezone ?? ""}>
+                            <span className="mx_UserInfo_timezone">
+                                <Text size="sm" weight="regular">
+                                    {timezoneInfo?.friendly ?? ""}
+                                </Text>
+                            </span>
+                        </Tooltip>
+                    )}
                     <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
                         <CopyableText getTextToCopy={() => userIdentifier} border={false}>
                             {userIdentifier}

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -29,6 +29,7 @@ import {
     User,
     Device,
     EventType,
+    MatrixError,
 } from "matrix-js-sdk/src/matrix";
 import { KnownMembership } from "matrix-js-sdk/src/types";
 import { UserVerificationStatus, VerificationRequest } from "matrix-js-sdk/src/crypto-api";
@@ -93,7 +94,7 @@ import { SdkContextClass } from "../../../contexts/SDKContext";
 import { asyncSome } from "../../../utils/arrays";
 import { Flex } from "../../utils/Flex";
 import CopyableText from "../elements/CopyableText";
-
+import { useUserTimezone } from "../../../hooks/useUserTimezone";
 export interface IDevice extends Device {
     ambiguous?: boolean;
 }
@@ -1703,28 +1704,7 @@ export const UserInfoHeader: React.FC<{
     }
 
 
-    // TODO: Check for support for this property.
-    const [timezone, setTimezone] = useState<{friendly: string, tz: string}>();
-    useEffect(() => {
-        cli.getExtendedProfileProperty(member.userId, 'us.cloke.msc4175.tz').then((value) => {
-            if (typeof value !== "string") {
-                // Err, definitely not a tz.
-                return;
-            }
-            try {
-                setTimezone(
-                    {
-                        friendly: new Date().toLocaleString(undefined, { timeZone: value, hour12: true, hour: "2-digit", minute: "2-digit", timeZoneName: "shortOffset"}),
-                        tz: value
-                    }
-                );
-            } catch (ex) {
-                console.error('Could not render current time for user', ex);
-            }
-        }).catch((ex) => {
-            console.error('Unable to load user timezone', ex);
-        });
-    }, [member.userId]);
+    const timezoneInfo = useUserTimezone(member.userId);
 
     const e2eIcon = e2eStatus ? <E2EIcon size={18} status={e2eStatus} isUser={true} /> : null;
     const userIdentifier = UserIdentifierCustomisations.getDisplayUserIdentifier?.(member.userId, {
@@ -1758,7 +1738,7 @@ export const UserInfoHeader: React.FC<{
                             {e2eIcon}
                         </Flex>
                     </Heading>
-                    {presenceLabel} {timezone && <Tooltip label={timezone.tz}><span>{timezone.friendly}</span></Tooltip>}
+                    {presenceLabel} {timezoneInfo && <Tooltip label={timezoneInfo.timezone}><span>{timezoneInfo.friendly}</span></Tooltip>}
                     <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
                         <CopyableText getTextToCopy={() => userIdentifier} border={false}>
                             {userIdentifier}

--- a/src/components/views/right_panel/UserInfo.tsx
+++ b/src/components/views/right_panel/UserInfo.tsx
@@ -1738,13 +1738,13 @@ export const UserInfoHeader: React.FC<{
                         </Flex>
                     </Heading>
                     {presenceLabel}
-                    <Tooltip label={timezoneInfo?.timezone ?? ""}>
+                    {timezoneInfo && <Tooltip label={timezoneInfo?.timezone ?? ""}>
                         <span className="mx_UserInfo_timezone">
                             <Text size="sm" weight="regular">
                                 {timezoneInfo?.friendly ?? ""}
                             </Text>
                         </span>
-                    </Tooltip>
+                    </Tooltip>}
                     <Text size="sm" weight="semibold" className="mx_UserInfo_profile_mxid">
                         <CopyableText getTextToCopy={() => userIdentifier} border={false}>
                             {userIdentifier}

--- a/src/components/views/settings/UserPersonalInfoSettings.tsx
+++ b/src/components/views/settings/UserPersonalInfoSettings.tsx
@@ -130,22 +130,6 @@ export const UserPersonalInfoSettings: React.FC<UserPersonalInfoSettingsProps> =
                     />
                 </ThreepidSectionWrapper>
             </SettingsSubsection>
-
-            <SettingsSubsection heading={_t("settings|general|timezone")} stretchContent legacy={false}>
-                <ThreepidSectionWrapper
-                    error={_t("settings|general|unable_to_load_msisdns")}
-                    loadingState={loadingState}
-                >
-                    <AddRemoveThreepids
-                        mode="hs"
-                        medium={ThreepidMedium.Phone}
-                        threepids={phoneNumbers!}
-                        onChange={onMsisdnsChange}
-                        disabled={!canMake3pidChanges}
-                        isLoading={loadingState === "loading"}
-                    />
-                </ThreepidSectionWrapper>
-            </SettingsSubsection>
         </div>
     );
 };

--- a/src/components/views/settings/UserPersonalInfoSettings.tsx
+++ b/src/components/views/settings/UserPersonalInfoSettings.tsx
@@ -131,11 +131,7 @@ export const UserPersonalInfoSettings: React.FC<UserPersonalInfoSettingsProps> =
                 </ThreepidSectionWrapper>
             </SettingsSubsection>
 
-            <SettingsSubsection
-                heading={_t("settings|general|timezone")}
-                stretchContent
-                legacy={false}
-            >
+            <SettingsSubsection heading={_t("settings|general|timezone")} stretchContent legacy={false}>
                 <ThreepidSectionWrapper
                     error={_t("settings|general|unable_to_load_msisdns")}
                     loadingState={loadingState}

--- a/src/components/views/settings/UserPersonalInfoSettings.tsx
+++ b/src/components/views/settings/UserPersonalInfoSettings.tsx
@@ -130,6 +130,26 @@ export const UserPersonalInfoSettings: React.FC<UserPersonalInfoSettingsProps> =
                     />
                 </ThreepidSectionWrapper>
             </SettingsSubsection>
+
+            <SettingsSubsection
+                heading={_t("settings|general|timezone")}
+                stretchContent
+                legacy={false}
+            >
+                <ThreepidSectionWrapper
+                    error={_t("settings|general|unable_to_load_msisdns")}
+                    loadingState={loadingState}
+                >
+                    <AddRemoveThreepids
+                        mode="hs"
+                        medium={ThreepidMedium.Phone}
+                        threepids={phoneNumbers!}
+                        onChange={onMsisdnsChange}
+                        disabled={!canMake3pidChanges}
+                        isLoading={loadingState === "loading"}
+                    />
+                </ThreepidSectionWrapper>
+            </SettingsSubsection>
         </div>
     );
 };

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -143,7 +143,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         "MessageComposerInput.insertTrailingColon",
     ];
 
-    private static TIME_SETTINGS = ["showTwelveHourTimestamps", "alwaysShowTimestamps", "userTimezonePublish"];
+    private static TIME_SETTINGS = ["showTwelveHourTimestamps", "alwaysShowTimestamps"];
 
     private static CODE_BLOCKS_SETTINGS = [
         "enableSyntaxHighlightLanguageDetection",
@@ -310,6 +310,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
                         </div>
 
                         {this.renderGroup(PreferencesUserSettingsTab.TIME_SETTINGS)}
+                        <SettingsFlag name="userTimezonePublish" level={SettingLevel.DEVICE} />
                     </SettingsSubsection>
 
                     <SettingsSubsection

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -143,7 +143,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         "MessageComposerInput.insertTrailingColon",
     ];
 
-    private static TIME_SETTINGS = ["showTwelveHourTimestamps", "alwaysShowTimestamps"];
+    private static TIME_SETTINGS = ["showTwelveHourTimestamps", "alwaysShowTimestamps", "userTimezonePublish"];
 
     private static CODE_BLOCKS_SETTINGS = [
         "enableSyntaxHighlightLanguageDetection",

--- a/src/hooks/useUserTimezone.ts
+++ b/src/hooks/useUserTimezone.ts
@@ -14,29 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { useEffect, useState } from "react";
-import { MatrixError } from "matrix-js-sdk/src/matrix";
-
-import { MatrixClientPeg } from "../MatrixClientPeg";
+import { MatrixClient, MatrixError } from "matrix-js-sdk/src/matrix";
 
 /**
  * Fetch a user's delclared timezone through their profile, and return
  * a friendly string of the current time for that user. This will keep
  * in sync with the current time, and will be refreshed once a minute.
  *
+ * @param cli The Matrix Client instance.
  * @param userId The userID to fetch the timezone for.
  * @returns A timezone name and friendly string for the user's timezone, or
  *          null if the user has no timezone or the timezone was not recognised
  *          by the browser.
  */
-export const useUserTimezone = (userId: string): { timezone: string; friendly: string } | null => {
+export const useUserTimezone = (cli: MatrixClient, userId: string): { timezone: string; friendly: string } | null => {
     const [timezone, setTimezone] = useState<string>();
     const [updateInterval, setUpdateInterval] = useState<number>();
     const [friendly, setFriendly] = useState<string>();
     const [supported, setSupported] = useState<boolean>();
-    const cli = MatrixClientPeg.safeGet();
 
     useEffect(() => {
-        if (supported !== undefined) {
+        if (!cli || supported !== undefined) {
             return;
         }
         cli.doesServerSupportExtendedProfiles()
@@ -59,6 +57,7 @@ export const useUserTimezone = (userId: string): { timezone: string; friendly: s
             return;
         }
         (async () => {
+            console.log("Trying to fetch TZ");
             try {
                 const tz = await cli.getExtendedProfileProperty(userId, "us.cloke.msc4175.tz");
                 if (typeof tz !== "string") {

--- a/src/hooks/useUserTimezone.ts
+++ b/src/hooks/useUserTimezone.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { MatrixClientPeg } from "../MatrixClientPeg";
+import { MatrixError } from "matrix-js-sdk/src/matrix";
+
+/**
+ * Fetch a user's delclared timezone through their profile, and return
+ * a friendly string of the current time for that user. This will keep
+ * in sync with the current time, and will be refreshed once a minute.
+ *
+ * @param userId The userID to fetch the timezone for.
+ * @returns A timezone name and friendly string for the user's timezone, or
+ *          null if the user has no timezone or the timezone was not recognised
+ *          by the browser.
+ */
+export const useUserTimezone = (userId: string): { timezone: string, friendly: string }|null => {
+    const [timezone, setTimezone] = useState<string>();
+    const [updateInterval, setUpdateInterval] = useState<number>();
+    const [friendly, setFriendly] = useState<string>();
+    const [supported, setSupported] = useState<boolean>();
+    const cli = MatrixClientPeg.safeGet();
+
+    useEffect(() => {
+        if (supported !== undefined) {
+            return;
+        }
+        cli.doesServerSupportExtendedProfiles().then(setSupported).catch((ex) => {
+            console.warn("Unable to determine if extended profiles are supported", ex);
+        });
+    }, [supported]);
+
+    useEffect(() => {
+        return () => {
+            if (updateInterval) {
+                clearInterval(updateInterval);
+            }
+        }
+    }, [updateInterval]);
+
+    useEffect(() => {
+        if (supported !== true) {
+            return;
+        }
+        (async () => {
+            try {
+                const tz = await cli.getExtendedProfileProperty(userId, 'us.cloke.msc4175.tz');
+                if (typeof tz !== "string") {
+                    // Err, definitely not a tz.
+                    throw Error('Timezone value was not a string');
+                }
+                // This will validate the timezone for us.
+                Intl.DateTimeFormat(undefined, {timeZone: tz});
+
+                const updateTime = () => {
+                    const currentTime = new Date();
+                    const friendly = currentTime.toLocaleString(undefined, { timeZone: tz, hour12: true, hour: "2-digit", minute: "2-digit", timeZoneName: "shortOffset"});
+                    setTimezone(tz);
+                    setFriendly(friendly);
+                    setUpdateInterval(setTimeout(updateTime, (60 - currentTime.getSeconds()) * 1000));
+                }
+                updateTime();
+            } catch (ex) {
+                setTimezone(undefined);
+                setFriendly(undefined);
+                setUpdateInterval(undefined);
+                if (ex instanceof MatrixError && ex.errcode === "M_NOT_FOUND") {
+                    // No timezone set, ignore.
+                    return;
+                }
+                console.error('Could not render current timezone for user', ex);
+            }
+        })();
+    }, [supported, userId]);
+
+    if (!timezone || !friendly) {
+        return null;
+    }
+
+    return {
+        friendly,
+        timezone
+    };
+}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2579,6 +2579,7 @@
             "remove_email_prompt": "Remove %(email)s?",
             "remove_msisdn_prompt": "Remove %(phone)s?",
             "spell_check_locale_placeholder": "Choose a locale",
+            "timezone": "settings|general|timezone",
             "unable_to_load_emails": "Unable to load email addresses",
             "unable_to_load_msisdns": "Unable to load phone numbers",
             "username": "Username"

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1426,6 +1426,7 @@
         "element_call_video_rooms": "Element Call video rooms",
         "experimental_description": "Feeling experimental? Try out our latest ideas in development. These features are not finalised; they may be unstable, may change, or may be dropped altogether. <a>Learn more</a>.",
         "experimental_section": "Early previews",
+        "extended_profiles_msc_support": "Requires your server to support MSC4133",
         "feature_disable_call_per_sender_encryption": "Disable per-sender encryption for Element Call",
         "feature_wysiwyg_composer_description": "Use rich text instead of Markdown in the message composer.",
         "group_calls": "New group call experience",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2579,7 +2579,6 @@
             "remove_email_prompt": "Remove %(email)s?",
             "remove_msisdn_prompt": "Remove %(phone)s?",
             "spell_check_locale_placeholder": "Choose a locale",
-            "timezone": "settings|general|timezone",
             "unable_to_load_emails": "Unable to load email addresses",
             "unable_to_load_msisdns": "Unable to load phone numbers",
             "username": "Username"

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2721,6 +2721,7 @@
             "keyboard_view_shortcuts_button": "To view all keyboard shortcuts, <a>click here</a>.",
             "media_heading": "Images, GIFs and videos",
             "presence_description": "Share your activity and status with others.",
+            "publish_timezone": "Publish timezone on public profile",
             "rm_lifetime": "Read Marker lifetime (ms)",
             "rm_lifetime_offscreen": "Read Marker off-screen lifetime (ms)",
             "room_directory_heading": "Room directory",

--- a/src/i18n/strings/pl.json
+++ b/src/i18n/strings/pl.json
@@ -1841,10 +1841,25 @@
         "files_button": "Pliki",
         "info": "Info",
         "pinned_messages": {
+            "empty_description": "Znajdź wiadomość i wybierz „%(pinAction)s”, aby załączyć ją tutaj.",
+            "empty_title": "Przypinaj ważne wiadomości, aby można było je łatwo znaleźć",
+            "header": {
+                "one": "Przypięto 1 wiadomość",
+                "few": "Przypięto %(count)s wiadomości",
+                "many": "Przypięto %(count)s wiadomości"
+            },
             "limits": {
                 "other": "Możesz przypiąć do %(count)s widżetów"
             },
-            "title": "Przypięte wiadomości"
+            "menu": "Otwórz menu",
+            "reply_thread": "Odpowiedz na <link>wiadomość w wątku</link>",
+            "title": "Przypięte wiadomości",
+            "unpin_all": {
+                "button": "Odepnij wszystkie wiadomości",
+                "content": "Upewnij się, czy naprawdę chcesz usunąć wszystkie przypięte wiadomości. Tej akcji nie można cofnąć.",
+                "title": "Odpiąć wszystkie wiadomości?"
+            },
+            "view": "Wyświetl na osi czasu"
         },
         "pinned_messages_button": "Przypięte wiadomości",
         "poll": {
@@ -2036,6 +2051,21 @@
         "not_found_title": "Ten pokój lub przestrzeń nie istnieje.",
         "not_found_title_name": "%(roomName)s nie istnieje.",
         "peek_join_prompt": "Przeglądasz %(roomName)s. Czy chcesz dołączyć do pokoju?",
+        "pinned_message_banner": {
+            "button_close_list": "Zamknij listę",
+            "button_view_all": "Pokaż wszystkie",
+            "description": "Ten pokój ma przypięte wiadomości. Kliknij, aby je wyświetlić.",
+            "go_to_message": "Wyświetl przypiętą wiadomość na osi czasu.",
+            "prefix": {
+                "audio": "Audio",
+                "file": "Plik",
+                "image": "Obraz",
+                "poll": "Ankieta",
+                "video": "Wideo"
+            },
+            "preview": "<bold>%(prefix)s:</bold> %(preview)s",
+            "title": "<bold>%(index)s z %(length)s</bold> przypiętych wiadomości"
+        },
         "read_topic": "Kliknij, aby przeczytać temat",
         "rejecting": "Odrzucanie zaproszenia…",
         "rejoin_button": "Dołącz ponownie",
@@ -2685,6 +2715,7 @@
             "code_blocks_heading": "Bloki kodu",
             "compact_modern": "Użyj bardziej kompaktowego, \"nowoczesnego\" wyglądu",
             "composer_heading": "Kompozytor",
+            "default_timezone": "Ustawienie przeglądarki (%(timezone)s)",
             "dialog_title": "<strong>Ustawienia:</strong> Preferencje",
             "enable_hardware_acceleration": "Włącz przyspieszenie sprzętowe",
             "enable_tray_icon": "Pokaż ikonę w zasobniku systemowym i zminimalizuj okno do niej zamiast zamknięcia",
@@ -2700,7 +2731,8 @@
             "show_checklist_shortcuts": "Pokaż skrót do listy powitalnej nad listą pokojów",
             "show_polls_button": "Pokaż przycisk ankiet",
             "surround_text": "Otocz zaznaczony tekst podczas wpisywania specjalnych znaków",
-            "time_heading": "Wyświetlanie czasu"
+            "time_heading": "Wyświetlanie czasu",
+            "user_timezone": "Ustaw strefę czasową"
         },
         "prompt_invite": "Powiadamiaj przed wysłaniem zaproszenia do potencjalnie nieprawidłowych ID matrix",
         "replace_plain_emoji": "Automatycznie zastępuj tekstowe emotikony",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -654,6 +654,12 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         displayName: _td("settings|preferences|user_timezone"),
         default: "",
     },
+    // TODO: How to make this visible based on server feature levels?
+    "userTimezonePublish": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td("settings|preferences|publish_timezone"),
+        default: false,
+    },
     "autoplayGifs": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("settings|autoplay_gifs"),

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -656,7 +656,8 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         default: "",
     },
     "userTimezonePublish": {
-        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        // This is per-device so you can avoid having devices overwrite each other.
+        supportedLevels: LEVELS_DEVICE_ONLY_SETTINGS,
         displayName: _td("settings|preferences|publish_timezone"),
         default: false,
         controller: new ServerSupportUnstableFeatureController(

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import React, { ReactNode } from "react";
+import { UNSTABLE_MSC4133_EXTENDED_PROFILES } from "matrix-js-sdk/src/matrix";
 
 import { _t, _td, TranslationKey } from "../languageHandler";
 import {
@@ -43,7 +44,6 @@ import ServerSupportUnstableFeatureController from "./controllers/ServerSupportU
 import { WatchManager } from "./WatchManager";
 import { CustomTheme } from "../theme";
 import AnalyticsController from "./controllers/AnalyticsController";
-import { UNSTABLE_MSC4133_EXTENDED_PROFILES } from "matrix-js-sdk/src/client"
 
 export const defaultWatchManager = new WatchManager();
 

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -43,6 +43,7 @@ import ServerSupportUnstableFeatureController from "./controllers/ServerSupportU
 import { WatchManager } from "./WatchManager";
 import { CustomTheme } from "../theme";
 import AnalyticsController from "./controllers/AnalyticsController";
+import { UNSTABLE_MSC4133_EXTENDED_PROFILES } from "matrix-js-sdk/src/client"
 
 export const defaultWatchManager = new WatchManager();
 
@@ -654,11 +655,17 @@ export const SETTINGS: { [setting: string]: ISetting } = {
         displayName: _td("settings|preferences|user_timezone"),
         default: "",
     },
-    // TODO: How to make this visible based on server feature levels?
     "userTimezonePublish": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,
         displayName: _td("settings|preferences|publish_timezone"),
         default: false,
+        controller: new ServerSupportUnstableFeatureController(
+            "userTimezonePublish",
+            defaultWatchManager,
+            [[UNSTABLE_MSC4133_EXTENDED_PROFILES]],
+            undefined,
+            _td("labs|extended_profiles_msc_support"),
+        ),
     },
     "autoplayGifs": {
         supportedLevels: LEVELS_ACCOUNT_SETTINGS,

--- a/test/components/views/right_panel/UserInfo-test.tsx
+++ b/test/components/views/right_panel/UserInfo-test.tsx
@@ -100,6 +100,7 @@ let mockRoom: Mocked<Room>;
 let mockSpace: Mocked<Room>;
 let mockClient: Mocked<MatrixClient>;
 let mockCrypto: Mocked<CryptoApi>;
+const origDate = global.Date.prototype.toLocaleString;
 
 beforeEach(() => {
     mockRoom = mocked({
@@ -240,10 +241,14 @@ describe("<UserInfo />", () => {
         });
 
         it("renders user timezone if set", async () => {
+            // For timezone, force a consistent locale.
+            jest.spyOn(global.Date.prototype, "toLocaleString").mockImplementation(function (_locale, opts) {
+                return origDate.call(this, "en-US", opts); // eslint-disable-line @typescript-eslint/no-invalid-this
+            });
             mockClient.doesServerSupportExtendedProfiles.mockResolvedValue(true);
             mockClient.getExtendedProfileProperty.mockResolvedValue("Europe/London");
             renderComponent();
-            await expect(screen.findByText(/\d\d:\d\d (am|pm)/)).resolves.toBeInTheDocument();
+            await expect(screen.findByText(/\d\d:\d\d (AM|PM)/)).resolves.toBeInTheDocument();
         });
 
         it("renders encryption info panel without pending verification", () => {

--- a/test/components/views/right_panel/UserInfo-test.tsx
+++ b/test/components/views/right_panel/UserInfo-test.tsx
@@ -158,6 +158,8 @@ beforeEach(() => {
         isSynapseAdministrator: jest.fn().mockResolvedValue(false),
         isRoomEncrypted: jest.fn().mockReturnValue(false),
         doesServerSupportUnstableFeature: jest.fn().mockReturnValue(false),
+        doesServerSupportExtendedProfiles: jest.fn().mockResolvedValue(false),
+        getExtendedProfileProperty: jest.fn().mockRejectedValue(new Error("Not supported")),
         mxcUrlToHttp: jest.fn().mockReturnValue("mock-mxcUrlToHttp"),
         removeListener: jest.fn(),
         currentState: {
@@ -235,6 +237,13 @@ describe("<UserInfo />", () => {
         it("renders user info", () => {
             renderComponent();
             expect(screen.getByRole("heading", { name: defaultUserId })).toBeInTheDocument();
+        });
+
+        it("renders user timezone if set", async () => {
+            mockClient.doesServerSupportExtendedProfiles.mockResolvedValue(true);
+            mockClient.getExtendedProfileProperty.mockResolvedValue("Europe/London");
+            renderComponent();
+            await expect(screen.findByText(/\d\d:\d\d (am|pm)/)).resolves.toBeInTheDocument();
         });
 
         it("renders encryption info panel without pending verification", () => {

--- a/test/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
+++ b/test/components/views/settings/tabs/user/__snapshots__/PreferencesUserSettingsTab-test.tsx.snap
@@ -307,6 +307,33 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   />
                 </div>
               </div>
+              <div
+                class="mx_SettingsFlag"
+              >
+                <label
+                  class="mx_SettingsFlag_label"
+                  for="mx_SettingsFlag_GQvdMWe954DV"
+                >
+                  <span
+                    class="mx_SettingsFlag_labelText"
+                  >
+                    Publish timezone on public profile
+                  </span>
+                </label>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-label="Publish timezone on public profile"
+                  class="mx_AccessibleButton mx_ToggleSwitch"
+                  id="mx_SettingsFlag_GQvdMWe954DV"
+                  role="switch"
+                  tabindex="0"
+                >
+                  <div
+                    class="mx_ToggleSwitch_ball"
+                  />
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -338,7 +365,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_GQvdMWe954DV"
+                  for="mx_SettingsFlag_IAu5CsiHRD7n"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -351,7 +378,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Send read receipts"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_GQvdMWe954DV"
+                  id="mx_SettingsFlag_IAu5CsiHRD7n"
                   role="switch"
                   tabindex="0"
                 >
@@ -365,7 +392,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_IAu5CsiHRD7n"
+                  for="mx_SettingsFlag_yrA2ohjWVJIP"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -378,7 +405,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Send typing notifications"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_IAu5CsiHRD7n"
+                  id="mx_SettingsFlag_yrA2ohjWVJIP"
                   role="switch"
                   tabindex="0"
                 >
@@ -409,7 +436,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_yrA2ohjWVJIP"
+                  for="mx_SettingsFlag_auy1OmnTidX4"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -422,7 +449,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Automatically replace plain text Emoji"
                   class="mx_AccessibleButton mx_ToggleSwitch"
-                  id="mx_SettingsFlag_yrA2ohjWVJIP"
+                  id="mx_SettingsFlag_auy1OmnTidX4"
                   role="switch"
                   tabindex="0"
                 >
@@ -436,7 +463,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_auy1OmnTidX4"
+                  for="mx_SettingsFlag_ePDS0OpWwAHG"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -460,33 +487,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Enable Markdown"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_auy1OmnTidX4"
-                  role="switch"
-                  tabindex="0"
-                >
-                  <div
-                    class="mx_ToggleSwitch_ball"
-                  />
-                </div>
-              </div>
-              <div
-                class="mx_SettingsFlag"
-              >
-                <label
-                  class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_ePDS0OpWwAHG"
-                >
-                  <span
-                    class="mx_SettingsFlag_labelText"
-                  >
-                    Enable Emoji suggestions while typing
-                  </span>
-                </label>
-                <div
-                  aria-checked="true"
-                  aria-disabled="true"
-                  aria-label="Enable Emoji suggestions while typing"
-                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_ePDS0OpWwAHG"
                   role="switch"
                   tabindex="0"
@@ -506,14 +506,14 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Use Ctrl + Enter to send a message
+                    Enable Emoji suggestions while typing
                   </span>
                 </label>
                 <div
-                  aria-checked="false"
+                  aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Use Ctrl + Enter to send a message"
-                  class="mx_AccessibleButton mx_ToggleSwitch"
+                  aria-label="Enable Emoji suggestions while typing"
+                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_75JNTNkNU64r"
                   role="switch"
                   tabindex="0"
@@ -533,13 +533,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Surround selected text when typing special characters
+                    Use Ctrl + Enter to send a message
                   </span>
                 </label>
                 <div
                   aria-checked="false"
                   aria-disabled="true"
-                  aria-label="Surround selected text when typing special characters"
+                  aria-label="Use Ctrl + Enter to send a message"
                   class="mx_AccessibleButton mx_ToggleSwitch"
                   id="mx_SettingsFlag_aTLcRsQRlYy7"
                   role="switch"
@@ -560,14 +560,14 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show stickers button
+                    Surround selected text when typing special characters
                   </span>
                 </label>
                 <div
-                  aria-checked="true"
+                  aria-checked="false"
                   aria-disabled="true"
-                  aria-label="Show stickers button"
-                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
+                  aria-label="Surround selected text when typing special characters"
+                  class="mx_AccessibleButton mx_ToggleSwitch"
                   id="mx_SettingsFlag_5nfv5bOEPN1s"
                   role="switch"
                   tabindex="0"
@@ -587,6 +587,33 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
+                    Show stickers button
+                  </span>
+                </label>
+                <div
+                  aria-checked="true"
+                  aria-disabled="true"
+                  aria-label="Show stickers button"
+                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
+                  id="mx_SettingsFlag_u1JYVtOyR5kb"
+                  role="switch"
+                  tabindex="0"
+                >
+                  <div
+                    class="mx_ToggleSwitch_ball"
+                  />
+                </div>
+              </div>
+              <div
+                class="mx_SettingsFlag"
+              >
+                <label
+                  class="mx_SettingsFlag_label"
+                  for="mx_SettingsFlag_u3pEwuLn9Enn"
+                >
+                  <span
+                    class="mx_SettingsFlag_labelText"
+                  >
                     Insert a trailing colon after user mentions at the start of a message
                   </span>
                 </label>
@@ -595,7 +622,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Insert a trailing colon after user mentions at the start of a message"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_u1JYVtOyR5kb"
+                  id="mx_SettingsFlag_u3pEwuLn9Enn"
                   role="switch"
                   tabindex="0"
                 >
@@ -626,7 +653,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_u3pEwuLn9Enn"
+                  for="mx_SettingsFlag_YuxfFEpOsztW"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -638,33 +665,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-checked="false"
                   aria-disabled="true"
                   aria-label="Enable automatic language detection for syntax highlighting"
-                  class="mx_AccessibleButton mx_ToggleSwitch"
-                  id="mx_SettingsFlag_u3pEwuLn9Enn"
-                  role="switch"
-                  tabindex="0"
-                >
-                  <div
-                    class="mx_ToggleSwitch_ball"
-                  />
-                </div>
-              </div>
-              <div
-                class="mx_SettingsFlag"
-              >
-                <label
-                  class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_YuxfFEpOsztW"
-                >
-                  <span
-                    class="mx_SettingsFlag_labelText"
-                  >
-                    Expand code blocks by default
-                  </span>
-                </label>
-                <div
-                  aria-checked="false"
-                  aria-disabled="true"
-                  aria-label="Expand code blocks by default"
                   class="mx_AccessibleButton mx_ToggleSwitch"
                   id="mx_SettingsFlag_YuxfFEpOsztW"
                   role="switch"
@@ -685,6 +685,33 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
+                    Expand code blocks by default
+                  </span>
+                </label>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-label="Expand code blocks by default"
+                  class="mx_AccessibleButton mx_ToggleSwitch"
+                  id="mx_SettingsFlag_hQkBerF1ejc4"
+                  role="switch"
+                  tabindex="0"
+                >
+                  <div
+                    class="mx_ToggleSwitch_ball"
+                  />
+                </div>
+              </div>
+              <div
+                class="mx_SettingsFlag"
+              >
+                <label
+                  class="mx_SettingsFlag_label"
+                  for="mx_SettingsFlag_GFes1UFzOK2n"
+                >
+                  <span
+                    class="mx_SettingsFlag_labelText"
+                  >
                     Show line numbers in code blocks
                   </span>
                 </label>
@@ -693,7 +720,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Show line numbers in code blocks"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_hQkBerF1ejc4"
+                  id="mx_SettingsFlag_GFes1UFzOK2n"
                   role="switch"
                   tabindex="0"
                 >
@@ -724,7 +751,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_GFes1UFzOK2n"
+                  for="mx_SettingsFlag_vfGFMldL2r2v"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -737,33 +764,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Enable inline URL previews by default"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_GFes1UFzOK2n"
-                  role="switch"
-                  tabindex="0"
-                >
-                  <div
-                    class="mx_ToggleSwitch_ball"
-                  />
-                </div>
-              </div>
-              <div
-                class="mx_SettingsFlag"
-              >
-                <label
-                  class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_vfGFMldL2r2v"
-                >
-                  <span
-                    class="mx_SettingsFlag_labelText"
-                  >
-                    Autoplay GIFs
-                  </span>
-                </label>
-                <div
-                  aria-checked="false"
-                  aria-disabled="true"
-                  aria-label="Autoplay GIFs"
-                  class="mx_AccessibleButton mx_ToggleSwitch"
                   id="mx_SettingsFlag_vfGFMldL2r2v"
                   role="switch"
                   tabindex="0"
@@ -783,13 +783,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Autoplay videos
+                    Autoplay GIFs
                   </span>
                 </label>
                 <div
                   aria-checked="false"
                   aria-disabled="true"
-                  aria-label="Autoplay videos"
+                  aria-label="Autoplay GIFs"
                   class="mx_AccessibleButton mx_ToggleSwitch"
                   id="mx_SettingsFlag_bsSwicmKUiOB"
                   role="switch"
@@ -810,6 +810,33 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
+                    Autoplay videos
+                  </span>
+                </label>
+                <div
+                  aria-checked="false"
+                  aria-disabled="true"
+                  aria-label="Autoplay videos"
+                  class="mx_AccessibleButton mx_ToggleSwitch"
+                  id="mx_SettingsFlag_dvqsxEaZtl3A"
+                  role="switch"
+                  tabindex="0"
+                >
+                  <div
+                    class="mx_ToggleSwitch_ball"
+                  />
+                </div>
+              </div>
+              <div
+                class="mx_SettingsFlag"
+              >
+                <label
+                  class="mx_SettingsFlag_label"
+                  for="mx_SettingsFlag_NIiWzqsApP1c"
+                >
+                  <span
+                    class="mx_SettingsFlag_labelText"
+                  >
                     Show previews/thumbnails for images
                   </span>
                 </label>
@@ -818,7 +845,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Show previews/thumbnails for images"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_dvqsxEaZtl3A"
+                  id="mx_SettingsFlag_NIiWzqsApP1c"
                   role="switch"
                   tabindex="0"
                 >
@@ -849,7 +876,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_NIiWzqsApP1c"
+                  for="mx_SettingsFlag_q1SIAPqLMVXh"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -861,33 +888,6 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-checked="true"
                   aria-disabled="true"
                   aria-label="Show typing notifications"
-                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_NIiWzqsApP1c"
-                  role="switch"
-                  tabindex="0"
-                >
-                  <div
-                    class="mx_ToggleSwitch_ball"
-                  />
-                </div>
-              </div>
-              <div
-                class="mx_SettingsFlag"
-              >
-                <label
-                  class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_q1SIAPqLMVXh"
-                >
-                  <span
-                    class="mx_SettingsFlag_labelText"
-                  >
-                    Show a placeholder for removed messages
-                  </span>
-                </label>
-                <div
-                  aria-checked="true"
-                  aria-disabled="true"
-                  aria-label="Show a placeholder for removed messages"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_q1SIAPqLMVXh"
                   role="switch"
@@ -908,13 +908,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show read receipts sent by other users
+                    Show a placeholder for removed messages
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show read receipts sent by other users"
+                  aria-label="Show a placeholder for removed messages"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_dXFDGgBsKXay"
                   role="switch"
@@ -935,13 +935,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show join/leave messages (invites/removes/bans unaffected)
+                    Show read receipts sent by other users
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show join/leave messages (invites/removes/bans unaffected)"
+                  aria-label="Show read receipts sent by other users"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_7Az0xw4Bs4Tt"
                   role="switch"
@@ -962,13 +962,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show display name changes
+                    Show join/leave messages (invites/removes/bans unaffected)
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show display name changes"
+                  aria-label="Show join/leave messages (invites/removes/bans unaffected)"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_8jmzPIlPoBCv"
                   role="switch"
@@ -989,13 +989,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show chat effects (animations when receiving e.g. confetti)
+                    Show display name changes
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show chat effects (animations when receiving e.g. confetti)"
+                  aria-label="Show display name changes"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_enFRaTjdsFou"
                   role="switch"
@@ -1016,13 +1016,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show profile picture changes
+                    Show chat effects (animations when receiving e.g. confetti)
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show profile picture changes"
+                  aria-label="Show chat effects (animations when receiving e.g. confetti)"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_bfwnd5rz4XNX"
                   role="switch"
@@ -1043,13 +1043,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Show avatars in user, room and event mentions
+                    Show profile picture changes
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Show avatars in user, room and event mentions"
+                  aria-label="Show profile picture changes"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_gs5uWEzYzZrS"
                   role="switch"
@@ -1070,13 +1070,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Enable big emoji in chat
+                    Show avatars in user, room and event mentions
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Enable big emoji in chat"
+                  aria-label="Show avatars in user, room and event mentions"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_qWg7OgID1yRR"
                   role="switch"
@@ -1097,13 +1097,13 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
-                    Jump to the bottom of the timeline when you send a message
+                    Enable big emoji in chat
                   </span>
                 </label>
                 <div
                   aria-checked="true"
                   aria-disabled="true"
-                  aria-label="Jump to the bottom of the timeline when you send a message"
+                  aria-label="Enable big emoji in chat"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
                   id="mx_SettingsFlag_pOPewl7rtMbV"
                   role="switch"
@@ -1124,6 +1124,33 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   <span
                     class="mx_SettingsFlag_labelText"
                   >
+                    Jump to the bottom of the timeline when you send a message
+                  </span>
+                </label>
+                <div
+                  aria-checked="true"
+                  aria-disabled="true"
+                  aria-label="Jump to the bottom of the timeline when you send a message"
+                  class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
+                  id="mx_SettingsFlag_cmt3PZSyNp3v"
+                  role="switch"
+                  tabindex="0"
+                >
+                  <div
+                    class="mx_ToggleSwitch_ball"
+                  />
+                </div>
+              </div>
+              <div
+                class="mx_SettingsFlag"
+              >
+                <label
+                  class="mx_SettingsFlag_label"
+                  for="mx_SettingsFlag_dJJz3lHUv9XX"
+                >
+                  <span
+                    class="mx_SettingsFlag_labelText"
+                  >
                     Show current profile picture and name for users in message history
                   </span>
                 </label>
@@ -1132,7 +1159,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Show current profile picture and name for users in message history"
                   class="mx_AccessibleButton mx_ToggleSwitch"
-                  id="mx_SettingsFlag_cmt3PZSyNp3v"
+                  id="mx_SettingsFlag_dJJz3lHUv9XX"
                   role="switch"
                   tabindex="0"
                 >
@@ -1163,7 +1190,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_dJJz3lHUv9XX"
+                  for="mx_SettingsFlag_SBSSOZDRlzlA"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -1176,7 +1203,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Show NSFW content"
                   class="mx_AccessibleButton mx_ToggleSwitch"
-                  id="mx_SettingsFlag_dJJz3lHUv9XX"
+                  id="mx_SettingsFlag_SBSSOZDRlzlA"
                   role="switch"
                   tabindex="0"
                 >
@@ -1207,7 +1234,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
               >
                 <label
                   class="mx_SettingsFlag_label"
-                  for="mx_SettingsFlag_SBSSOZDRlzlA"
+                  for="mx_SettingsFlag_FLEpLCb0jpp6"
                 >
                   <span
                     class="mx_SettingsFlag_labelText"
@@ -1220,7 +1247,7 @@ exports[`PreferencesUserSettingsTab should render 1`] = `
                   aria-disabled="true"
                   aria-label="Prompt before sending invites to potentially invalid matrix IDs"
                   class="mx_AccessibleButton mx_ToggleSwitch mx_ToggleSwitch_on"
-                  id="mx_SettingsFlag_SBSSOZDRlzlA"
+                  id="mx_SettingsFlag_FLEpLCb0jpp6"
                   role="switch"
                   tabindex="0"
                 >


### PR DESCRIPTION
Migrated from https://github.com/matrix-org/matrix-react-sdk/pull/12967
Implements [MSC4175](https://github.com/matrix-org/matrix-spec-proposals/pull/4175)
Depends on https://github.com/matrix-org/matrix-js-sdk/pull/4391

Design provided at https://www.figma.com/design/gpxHFDTNK796n84r1ZxYG2?node-id=1360-28954#941702635

This provides a basic presentation of a user's current time & timezone on their profile. It also adds a setting to allow publishing the time.

### Timezone in user profile

![image](https://github.com/user-attachments/assets/3a65f419-c8d4-4060-b0bc-9d76549091f7)


### Timezone publish setting

![image](https://github.com/user-attachments/assets/834b9fca-fb7c-4c23-b88a-54a9a72a5ffc)


## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/matrix-org/matrix-react-sdk/blob/develop/CONTRIBUTING.md)).
