### PR TITLE
Implement MSC4142: Remove unintentional intentional mentions in replies

### DIFF
--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -100,12 +100,6 @@ export function attachMentions(
     // event + any mentioned users in that event.
     if (replyToEvent) {
         userMentions.add(replyToEvent.sender!.userId);
-        // TODO What do we do if the reply event *doeesn't* have this property?
-        // Try to fish out replies from the contents?
-        const userIds = replyToEvent.getContent()["m.mentions"]?.user_ids;
-        if (Array.isArray(userIds)) {
-            userIds.forEach((userId) => userMentions.add(userId));
-        }
     }
 
     // If user provided content is available, check to see if any users are mentioned.

--- a/test/components/views/rooms/EditMessageComposer-test.tsx
+++ b/test/components/views/rooms/EditMessageComposer-test.tsx
@@ -432,8 +432,6 @@ describe("<EditMessageComposer/>", () => {
                     user_ids: [
                         // sender of event we replied to
                         originalEvent.getSender()!,
-                        // mentions from this event
-                        "@bob:server.org",
                     ],
                 },
             },

--- a/test/components/views/rooms/SendMessageComposer-test.tsx
+++ b/test/components/views/rooms/SendMessageComposer-test.tsx
@@ -196,7 +196,7 @@ describe("<SendMessageComposer/>", () => {
                 "m.mentions": { user_ids: ["@bob:test"] },
             });
 
-            // It also adds any other mentioned users, but removes yourself.
+            // It no longer adds any other mentioned users
             replyToEvent = mkEvent({
                 type: "m.room.message",
                 user: "@bob:test",
@@ -207,7 +207,7 @@ describe("<SendMessageComposer/>", () => {
             content = {};
             attachMentions("@alice:test", content, model, replyToEvent);
             expect(content).toEqual({
-                "m.mentions": { user_ids: ["@bob:test", "@charlie:test"] },
+                "m.mentions": { user_ids: ["@bob:test"] },
             });
         });
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/27291
Implements https://github.com/matrix-org/matrix-spec-proposals/pull/4142
Re-opened version of https://github.com/matrix-org/matrix-react-sdk/pull/12511

The [current spec](https://spec.matrix.org/v1.11/client-server-api/#mentioning-the-replied-to-user) is just a recommendation, so following it is not required and this can be merged already before the MSC is accepted. The goal of the MSC is to remove the dumb recommendation from the spec

For context:

* **Old behavior before intentional mentions**: reply fallbacks caused replies to mention the sender of the replied-to message, as well as any users explicitly mentioned in the replied-to message
* **Current behavior in Element**: replies mention the sender of the replied-to message, as well as all users explicitly or implicitly mentioned in the replied-to message. Implicit mentions includes any mentions from earlier in the reply chain (like the senders of all previous messages and any users ever mentioned in the chain)
* **New behavior after this PR**: replies mention the sender of the replied-to message

In all cases, new explicit mentions are also of course included