### PR TITLE
Update to use non deprecated methods to derive key from passphrase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,6 @@ module.exports = {
                             "!matrix-js-sdk/src/crypto/aes",
                             "!matrix-js-sdk/src/crypto/keybackup",
                             "!matrix-js-sdk/src/crypto/deviceinfo",
-                            "!matrix-js-sdk/src/crypto/key_passphrase",
                             "!matrix-js-sdk/src/crypto/recoverykey",
                             "!matrix-js-sdk/src/crypto/dehydration",
                             "!matrix-js-sdk/src/oidc",

--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -7,7 +7,7 @@ Please see LICENSE files in the repository root for full details.
 */
 
 import { ICryptoCallbacks, SecretStorage } from "matrix-js-sdk/src/matrix";
-import { deriveKey } from "matrix-js-sdk/src/crypto/key_passphrase";
+import { deriveRecoveryKeyFromPassphrase } from "matrix-js-sdk/src/crypto-api";
 import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
 import { logger } from "matrix-js-sdk/src/logger";
 
@@ -64,7 +64,7 @@ function makeInputToKey(
 ): (keyParams: KeyParams) => Promise<Uint8Array> {
     return async ({ passphrase, recoveryKey }): Promise<Uint8Array> => {
         if (passphrase) {
-            return deriveKey(passphrase, keyInfo.passphrase.salt, keyInfo.passphrase.iterations);
+            return deriveRecoveryKeyFromPassphrase(passphrase, keyInfo.passphrase.salt, keyInfo.passphrase.iterations);
         } else if (recoveryKey) {
             return decodeRecoveryKey(recoveryKey);
         }


### PR DESCRIPTION
 <!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/matrix-react-sdk)

Task https://github.com/element-hq/element-web/issues/26922
Following https://github.com/matrix-org/matrix-js-sdk/pull/440, update react-sdk to replace deprecated methods

I didn't change the usage of `MatrixClient.keyBackupKeyFromPassword` in `RestoreKeyBackupDialog.tsx` since deriving a key backup from a password is not a part of the matrix spec. We will need to change the ui to get rid of this option.
