### PR TITLE
Replace old reference of `matrix-org/matrix-react-sdk` by `element-hq/matrix-react-sdk` in CI

### DIFF
--- a/.github/workflows/notify-element-web.yml
+++ b/.github/workflows/notify-element-web.yml
@@ -9,7 +9,7 @@ jobs:
         name: "Notify Element Web"
         runs-on: ubuntu-latest
         # Only respect triggers from our develop branch, ignore that of forks
-        if: github.repository == 'matrix-org/matrix-react-sdk'
+        if: github.repository == 'element-hq/matrix-react-sdk'
         steps:
             - name: Notify element-web repo that a new SDK build is on develop
               uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
               with:
-                  repository: ${{ inputs.matrix-js-sdk-sha && 'matrix-org/matrix-react-sdk' || github.repository }}
+                  repository: ${{ inputs.matrix-js-sdk-sha && 'element-hq/matrix-react-sdk' || github.repository }}
 
             - name: Yarn cache
               uses: actions/setup-node@v4
@@ -111,7 +111,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  repository: ${{ inputs.matrix-js-sdk-sha && 'matrix-org/matrix-react-sdk' || github.repository }}
+                  repository: ${{ inputs.matrix-js-sdk-sha && 'element-hq/matrix-react-sdk' || github.repository }}
 
             - uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/matrix-react-sdk)
