### PR TITLE
Fix bell icons on room list hover being black squares

### DIFF
--- a/src/stores/ReadyWatchingStore.ts
+++ b/src/stores/ReadyWatchingStore.ts
@@ -29,6 +29,8 @@ export abstract class ReadyWatchingStore extends EventEmitter implements IDestro
         super();
 
         this.dispatcherRef = this.dispatcher.register(this.onAction);
+
+        ReadyWatchingStore.instances.push(this);
     }
 
     public get matrixClient(): MatrixClient | null {

--- a/test/MatrixClientPeg-test.ts
+++ b/test/MatrixClientPeg-test.ts
@@ -6,6 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only
 Please see LICENSE files in the repository root for full details.
 */
 
+import * as MatrixJs from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import fetchMockJest from "fetch-mock-jest";
 
@@ -19,9 +20,14 @@ jest.useFakeTimers();
 const PegClass = Object.getPrototypeOf(peg).constructor;
 
 describe("MatrixClientPeg", () => {
+    let mockClient: MatrixJs.MatrixClient;
+
     beforeEach(() => {
         // stub out Logger.log which gets called a lot and clutters up the test output
         jest.spyOn(logger, "log").mockImplementation(() => {});
+
+        mockClient = stubClient();
+        jest.spyOn(MatrixJs, "createClient").mockReturnValue(mockClient);
     });
 
     afterEach(() => {
@@ -33,7 +39,6 @@ describe("MatrixClientPeg", () => {
     });
 
     it("setJustRegisteredUserId", () => {
-        stubClient();
         (peg as any).matrixClient = peg.get();
         peg.setJustRegisteredUserId("@userId:matrix.org");
         expect(peg.safeGet().credentials.userId).toBe("@userId:matrix.org");
@@ -52,7 +57,6 @@ describe("MatrixClientPeg", () => {
     });
 
     it("setJustRegisteredUserId(null)", () => {
-        stubClient();
         (peg as any).matrixClient = peg.get();
         peg.setJustRegisteredUserId(null);
         expect(peg.currentUserIsJustRegistered()).toBe(false);
@@ -72,6 +76,7 @@ describe("MatrixClientPeg", () => {
             // instantiate a MatrixClientPegClass instance, with a new MatrixClient
             testPeg = new PegClass();
             fetchMockJest.get("http://example.com/_matrix/client/versions", {});
+            fetchMockJest.get("http://example.com/_matrix/client/v3/pushrules", {});
             testPeg.replaceUsingCreds({
                 accessToken: "SEKRET",
                 homeserverUrl: "http://example.com",
@@ -83,13 +88,10 @@ describe("MatrixClientPeg", () => {
         it("should initialise the rust crypto library by default", async () => {
             const mockSetValue = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
 
-            const mockInitCrypto = jest.spyOn(testPeg.safeGet(), "initCrypto").mockResolvedValue(undefined);
-            const mockInitRustCrypto = jest.spyOn(testPeg.safeGet(), "initRustCrypto").mockResolvedValue(undefined);
-
             const cryptoStoreKey = new Uint8Array([1, 2, 3, 4]);
             await testPeg.start({ rustCryptoStoreKey: cryptoStoreKey });
-            expect(mockInitCrypto).not.toHaveBeenCalled();
-            expect(mockInitRustCrypto).toHaveBeenCalledWith({ storageKey: cryptoStoreKey });
+            expect(mockClient.initCrypto).not.toHaveBeenCalled();
+            expect(mockClient.initRustCrypto).toHaveBeenCalledWith({ storageKey: cryptoStoreKey });
 
             // we should have stashed the setting in the settings store
             expect(mockSetValue).toHaveBeenCalledWith("feature_rust_crypto", null, SettingLevel.DEVICE, true);
@@ -97,10 +99,9 @@ describe("MatrixClientPeg", () => {
 
         it("Should migrate existing login", async () => {
             const mockSetValue = jest.spyOn(SettingsStore, "setValue").mockResolvedValue(undefined);
-            const mockInitRustCrypto = jest.spyOn(testPeg.safeGet(), "initRustCrypto").mockResolvedValue(undefined);
 
             await testPeg.start();
-            expect(mockInitRustCrypto).toHaveBeenCalledTimes(1);
+            expect(mockClient.initRustCrypto).toHaveBeenCalledTimes(1);
 
             // we should have stashed the setting in the settings store
             expect(mockSetValue).toHaveBeenCalledWith("feature_rust_crypto", null, SettingLevel.DEVICE, true);

--- a/test/MatrixClientPeg-test.ts
+++ b/test/MatrixClientPeg-test.ts
@@ -8,7 +8,6 @@ Please see LICENSE files in the repository root for full details.
 
 import * as MatrixJs from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
-import fetchMockJest from "fetch-mock-jest";
 
 import { advanceDateAndTime, stubClient } from "./test-utils";
 import { IMatrixClientPeg, MatrixClientPeg as peg } from "../src/MatrixClientPeg";
@@ -75,8 +74,6 @@ describe("MatrixClientPeg", () => {
         beforeEach(() => {
             // instantiate a MatrixClientPegClass instance, with a new MatrixClient
             testPeg = new PegClass();
-            fetchMockJest.get("http://example.com/_matrix/client/versions", {});
-            fetchMockJest.get("http://example.com/_matrix/client/v3/pushrules", {});
             testPeg.replaceUsingCreds({
                 accessToken: "SEKRET",
                 homeserverUrl: "http://example.com",

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -86,6 +86,7 @@ export function createTestClient(): MatrixClient {
     let txnId = 1;
 
     const client = {
+        startClient: jest.fn(),
         getHomeserverUrl: jest.fn(),
         getIdentityServerUrl: jest.fn(),
         getDomain: jest.fn().mockReturnValue("matrix.org"),
@@ -133,6 +134,8 @@ export function createTestClient(): MatrixClient {
             getVerificationRequestsToDeviceInProgress: jest.fn().mockReturnValue([]),
             setDeviceIsolationMode: jest.fn(),
         }),
+        initCrypto: jest.fn(),
+        initRustCrypto: jest.fn(),
 
         getPushActionsForEvent: jest.fn(),
         getRoom: jest.fn().mockImplementation((roomId) => mkStubRoom(roomId, "My room", client)),
@@ -180,6 +183,7 @@ export function createTestClient(): MatrixClient {
         getSyncState: jest.fn().mockReturnValue("SYNCING"),
         generateClientSecret: () => "t35tcl1Ent5ECr3T",
         isGuest: jest.fn().mockReturnValue(false),
+        setGuest: jest.fn(),
         getRoomHierarchy: jest.fn().mockReturnValue({
             rooms: [],
         }),
@@ -277,6 +281,7 @@ export function createTestClient(): MatrixClient {
         isFallbackICEServerAllowed: jest.fn().mockReturnValue(false),
         getAuthIssuer: jest.fn(),
         getOrCreateFilter: jest.fn(),
+        setNotifTimelineSet: jest.fn(),
     } as unknown as MatrixClient;
 
     client.reEmitter = new ReEmitter(client);

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -93,7 +93,7 @@ export function createTestClient(): MatrixClient {
         getUserId: jest.fn().mockReturnValue("@userId:matrix.org"),
         getSafeUserId: jest.fn().mockReturnValue("@userId:matrix.org"),
         getUserIdLocalpart: jest.fn().mockResolvedValue("userId"),
-        getUser: jest.fn().mockReturnValue({ on: jest.fn(), off: jest.fn() }),
+        getUser: jest.fn().mockReturnValue({ on: jest.fn(), off: jest.fn(), removeListener: jest.fn() }),
         getDevice: jest.fn(),
         getDeviceId: jest.fn().mockReturnValue("ABCDEFGHI"),
         getStoredCrossSigningForUser: jest.fn(),


### PR DESCRIPTION
The EchoStore wasn't being set up and therefore missed the client being injected.

Patch from @t3chguy.

Fixes https://github.com/element-hq/element-web/issues/28169

Also fixed the MatrixClientPeg test to actually just test the clientpeg class rather than spinning up a real client and trying to start it, because otherwise it was failing in weird ways.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/matrix-react-sdk)
