### PR TITLE
Fix vertical overflow on the mobile register screen

### DIFF
--- a/res/css/structures/auth/_MobileRegistration.pcss
+++ b/res/css/structures/auth/_MobileRegistration.pcss
@@ -7,4 +7,6 @@ Please see LICENSE files in the repository root for full details.
 
 .mx_MobileRegister_body {
     padding: 32px;
+    height: 100vh;
+    overflow-y: auto;
 }

--- a/res/css/structures/auth/_MobileRegistration.pcss
+++ b/res/css/structures/auth/_MobileRegistration.pcss
@@ -9,4 +9,5 @@ Please see LICENSE files in the repository root for full details.
     padding: 32px;
     height: 100vh;
     overflow-y: auto;
+    box-sizing: border-box;
 }


### PR DESCRIPTION
## What's in this PR
It fixes a bug whereby the mobile register screen could not be scrolled at small resolutions. I think this is wasn't caught before, as generally the mobile screen sizes are big enough to render this.

## Before (can't scroll)

https://github.com/user-attachments/assets/a6a08d8f-fdf6-40d5-a36d-c95f0be0e670


## After


https://github.com/user-attachments/assets/5ce9d540-d299-4874-b284-136980f29d05

