### PR TITLE
Replace `MatrixClient.checkSecretStorageKey` by `MatrixClient.SecretStorage.checkKey`

### DIFF
--- a/src/SecurityManager.ts
+++ b/src/SecurityManager.ts
@@ -121,7 +121,7 @@ async function getSecretStorageKey({
             keyInfo,
             checkPrivateKey: async (input: KeyParams): Promise<boolean> => {
                 const key = await inputToKey(input);
-                return MatrixClientPeg.safeGet().checkSecretStorageKey(key, keyInfo);
+                return MatrixClientPeg.safeGet().secretStorage.checkKey(key, keyInfo);
             },
         },
         /* className= */ undefined,

--- a/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
+++ b/src/components/views/dialogs/security/AccessSecretStorageDialog.tsx
@@ -102,7 +102,7 @@ export default class AccessSecretStorageDialog extends React.PureComponent<IProp
         try {
             const cli = MatrixClientPeg.safeGet();
             const decodedKey = decodeRecoveryKey(this.state.recoveryKey);
-            const correct = await cli.checkSecretStorageKey(decodedKey, this.props.keyInfo);
+            const correct = await cli.secretStorage.checkKey(decodedKey, this.props.keyInfo);
             this.setState({
                 recoveryKeyValid: true,
                 recoveryKeyCorrect: correct,

--- a/test/components/views/dialogs/AccessSecretStorageDialog-test.tsx
+++ b/test/components/views/dialogs/AccessSecretStorageDialog-test.tsx
@@ -10,15 +10,14 @@ import React, { ComponentProps } from "react";
 import { SecretStorage, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Mocked } from "jest-mock";
 
-import { getMockClientWithEventEmitter, mockPlatformPeg } from "../../../test-utils";
+import { mockPlatformPeg, stubClient } from "../../../test-utils";
 import AccessSecretStorageDialog from "../../../../src/components/views/dialogs/security/AccessSecretStorageDialog";
 
 const securityKey = "EsTc WKmb ivvk jLS7 Y1NH 5CcQ mP1E JJwj B3Fd pFWm t4Dp dbyu";
 
 describe("AccessSecretStorageDialog", () => {
-    let mockClient: Mocked<MatrixClient>;
+    let mockClient: MatrixClient;
 
     const defaultProps: ComponentProps<typeof AccessSecretStorageDialog> = {
         keyInfo: {} as any,
@@ -57,13 +56,11 @@ describe("AccessSecretStorageDialog", () => {
     });
 
     beforeEach(() => {
-        mockClient = getMockClientWithEventEmitter({
-            checkSecretStorageKey: jest.fn(),
-        });
+        mockClient = stubClient();
     });
 
     it("Closes the dialog when the form is submitted with a valid key", async () => {
-        mockClient.checkSecretStorageKey.mockResolvedValue(true);
+        jest.spyOn(mockClient.secretStorage, "checkKey").mockResolvedValue(true);
 
         const onFinished = jest.fn();
         const checkPrivateKey = jest.fn().mockResolvedValue(true);
@@ -85,7 +82,7 @@ describe("AccessSecretStorageDialog", () => {
         const checkPrivateKey = jest.fn().mockResolvedValue(true);
         renderComponent({ onFinished, checkPrivateKey });
 
-        mockClient.checkSecretStorageKey.mockImplementation(() => {
+        jest.spyOn(mockClient.secretStorage, "checkKey").mockImplementation(() => {
             throw new Error("invalid key");
         });
 

--- a/test/test-utils/test-utils.ts
+++ b/test/test-utils/test-utils.ts
@@ -109,6 +109,7 @@ export function createTestClient(): MatrixClient {
         secretStorage: {
             get: jest.fn(),
             isStored: jest.fn().mockReturnValue(false),
+            checkKey: jest.fn().mockResolvedValue(false),
         },
 
         store: {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/matrix-react-sdk)

Task https://github.com/element-hq/element-web/issues/26922
Replace deprecated `MatrixClient.checkSecretStorageKey` by `MatrixClient.SecretStorage.checkKey`